### PR TITLE
Fix aws addition slowing down chown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,9 @@ WORKDIR /odyssey
 # Install software
 RUN apt-get update && apt-get --yes install cron sudo
 RUN wget "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -O "awscliv2.zip" && \
-	unzip awscliv2.zip && \
-	./aws/install
+	unzip awscliv2.zip -d /tmp && \
+	/tmp/aws/install && \
+	rm -rf /tmp/aws
 
 # Make plugins folder
 RUN mkdir plugins

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN ln -s configs/server.properties server.properties && \
 EXPOSE 8123 25565
 
 # Create the user
-ARG username=root
+ARG username=worker
 RUN useradd -m ${username} && \
 	chown -R ${username}:${username} . && \
 	usermod -aG sudo ${username} && \


### PR DESCRIPTION
Fixes slow chown-ing the working directory to the primary user caused by the AWS CLI being unpacked into the pwd.

The CLI is now unzipped into /tmp, installed, and then the installation files are removed.

While this was tested to ensure the AWS cli exists on the path, full functionality was not tested.
Removing the installation files can be omitted if the cli is found to still require them.